### PR TITLE
Dailymotion Bid Adaptor: initial release

### DIFF
--- a/modules/dailymotionBidAdapter.js
+++ b/modules/dailymotionBidAdapter.js
@@ -1,0 +1,55 @@
+import { config } from '../src/config.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { VIDEO } from '../src/mediaTypes.js';
+
+export const spec = {
+  code: 'dailymotion',
+  gvlid: 573,
+  supportedMediaTypes: [VIDEO],
+
+  /**
+   * Determines whether or not the given bid request is valid.
+   * The only mandatory parameters for a bid to be valid are the api_key and position configuration entries.
+   * Other parameters are optional.
+   *
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: () => {
+    const dmConfig = config.getConfig('dailymotion');
+    return !!(dmConfig?.api_key && dmConfig?.position);
+  },
+
+  /**
+   * Make a server request from the list of valid BidRequests (that already passed the isBidRequestValid call)
+   *
+   * @param {BidRequest[]} validBidRequests A non-empty list of valid bid requests that should be sent to the Server.
+   * @param {BidderRequest} bidderRequest
+   * @return ServerRequest Info describing the request to the server.
+   */
+  buildRequests: (validBidRequests = [], bidderRequest) => validBidRequests.map(bid => ({
+    method: 'POST',
+    url: 'https://pb.dmxleo.com',
+    data: {
+      bidder_request: bidderRequest,
+      config: config.getConfig('dailymotion'),
+      coppa: config.getConfig('coppa'),
+      request: bid,
+    },
+    options: {
+      withCredentials: true,
+      crossOrigin: true
+    },
+  })),
+
+  /**
+   * Map the response from the server into a list of bids.
+   * As dailymotion prebid server returns an entry with the correct Prebid structure,
+   * we directly include it as the only bid in the response.
+   *
+   * @param {*} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
+  interpretResponse: serverResponse => serverResponse?.body ? [serverResponse.body] : [],
+};
+
+registerBidder(spec);

--- a/modules/dailymotionBidAdapter.md
+++ b/modules/dailymotionBidAdapter.md
@@ -1,0 +1,73 @@
+# Overview
+
+```
+Module Name: Dailymotion Bid Adapter
+Module Type: Bidder Adapter
+Maintainer: ad-leo-engineering@dailymotion.com
+```
+
+# Description
+
+Dailymotion prebid adapter.
+
+# Configuration options
+
+Before calling this adapter, you need to set its configuration with a call to setConfig like this:
+
+```
+config.setConfig({
+  dailymotion: {
+    api_key: 'test_api_key',
+    position: 'test_position',
+    xid: 'x123456'
+  }
+});
+```
+
+This call must be made before each auction. Here's a description of each parameter:
+* `api_key` is your publisher API key. For testing purpose, you can use "dailymotion-testing".
+* `position` parameter is the ad position in the video and must either be "preroll", "midroll" or "postroll".
+* `xid` is the Dailymotion video identifier and should be provided to have better contextual data and higher fillrate.
+
+# Test Parameters
+
+By setting the following configuration options, you'll get a constant response to any request to validate your adapter integration:
+
+```
+config.setConfig({
+  dailymotion: {
+    api_key: 'dailymotion-testing',
+    position: 'preroll'
+  }
+});
+```
+
+Please note that failing to set these configuration options will result in the adapter not bidding at all.
+
+# Sample video AdUnit
+
+```
+const adUnits = [
+  {
+    code: 'test-ad-unit',
+    mediaTypes: {
+      video: {
+        context: 'instream',
+        playerSize: [1280, 720],
+      },
+    },
+    bids: [{
+      bidder: "dailymotion",
+      params: {}
+    }]
+  }
+];
+```
+
+# Integrating the adapter
+
+To use the adapter with any non-test request, you first need to ask an API key from Dailymotion. Please contact us through **DailymotionPrebid.js@dailymotion.com**.
+
+You will then be able to use it within the `config` before making a bid request.
+
+This API key will ensure proper identification of your inventory and allow you to get real bids.

--- a/test/spec/modules/dailymotionBidAdapter_spec.js
+++ b/test/spec/modules/dailymotionBidAdapter_spec.js
@@ -1,0 +1,148 @@
+import { config } from 'src/config.js';
+import { expect } from 'chai';
+import { spec } from 'modules/dailymotionBidAdapter.js';
+
+describe('dailymotionBidAdapterTests', () => {
+  // Validate that isBidRequestValid only validates requests
+  // with both api_key and position config parameters set
+  it('validates isBidRequestValid', () => {
+    config.setConfig({ dailymotion: {} });
+    expect(spec.isBidRequestValid({
+      bidder: 'dailymotion',
+    })).to.be.false;
+
+    config.setConfig({ dailymotion: { api_key: 'test_api_key' } });
+    expect(spec.isBidRequestValid({
+      bidder: 'dailymotion',
+    })).to.be.false;
+
+    config.setConfig({ dailymotion: { position: 'test_position' } });
+    expect(spec.isBidRequestValid({
+      bidder: 'dailymotion',
+    })).to.be.false;
+
+    config.setConfig({ dailymotion: { api_key: 'test_api_key', position: 'test_position' } });
+    expect(spec.isBidRequestValid({
+      bidder: 'dailymotion',
+    })).to.be.true;
+  });
+
+  // Validate request generation with api key & position only
+  it('validates buildRequests - with api key & position', () => {
+    const dmConfig = { api_key: 'test_api_key', position: 'test_position' };
+
+    config.setConfig({
+      dailymotion: dmConfig,
+      coppa: true,
+    });
+
+    const bidRequestData = [{
+      adUnitCode: 'test_adunitcode',
+      auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+      bidId: 123456,
+      bidder: 'dailymotion',
+    }];
+
+    const bidderRequestData = {
+      uspConsent: '1YN-',
+      gdprConsent: {
+        consentString: 'xxx',
+        gdprApplies: 1
+      },
+    };
+
+    const [request] = spec.buildRequests(bidRequestData, bidderRequestData);
+    const { data: reqData } = request;
+
+    expect(request.url).to.equal('https://pb.dmxleo.com');
+    expect(reqData.bidder_request).to.equal(bidderRequestData)
+    expect(reqData.config).to.equal(dmConfig);
+    expect(reqData.coppa).to.be.true;
+    expect(reqData.request).to.equal(bidRequestData[0]);
+  });
+
+  // Validate request generation with api key, position, xid
+  it('validates buildRequests - with auth & xid', function () {
+    const dmConfig = {
+      api_key: 'test_api_key',
+      position: 'test_position',
+      xid: 'x123456',
+    };
+
+    config.setConfig({ dailymotion: dmConfig });
+
+    const bidRequestData = [{
+      adUnitCode: 'test_adunitcode',
+      auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+      bidId: 123456,
+      bidder: 'dailymotion',
+    }];
+
+    const bidderRequestData = {
+      uspConsent: '1YN-',
+      gdprConsent: {
+        consentString: 'xxx',
+        gdprApplies: 1
+      },
+    };
+
+    const [request] = spec.buildRequests(bidRequestData, bidderRequestData);
+    const { data: reqData } = request;
+
+    expect(request.url).to.equal('https://pb.dmxleo.com');
+    expect(reqData.bidder_request).to.equal(bidderRequestData)
+    expect(reqData.config).to.equal(dmConfig);
+    expect(reqData.coppa).to.equal(true);
+    expect(reqData.request).to.equal(bidRequestData[0]);
+  });
+
+  it('validates buildRequests - with empty/undefined validBidRequests', function () {
+    const dmConfig = {
+      api_key: 'test_api_key',
+      position: 'test_position',
+      xid: 'x123456',
+    };
+
+    config.setConfig({ dailymotion: dmConfig });
+
+    expect(spec.buildRequests([], {})).to.have.lengthOf(0);
+
+    expect(spec.buildRequests(undefined, {})).to.have.lengthOf(0);
+  });
+
+  it('validates interpretResponse', function () {
+    const serverResponse = {
+      body: {
+        ad: 'https://fakecacheserver/cache?uuid=1234',
+        cacheId: '1234',
+        cpm: 20.0,
+        creativeId: '5678',
+        currency: 'USD',
+        dealId: 'deal123',
+        nurl: 'https://bid/nurl',
+        requestId: 'test_requestid',
+        vastUrl: 'https://fakecacheserver/cache?uuid=1234',
+      },
+    };
+
+    const bids = spec.interpretResponse(serverResponse);
+    expect(bids).to.have.lengthOf(1);
+
+    const [bid] = bids;
+    expect(bid.ad).to.equal(serverResponse.body.ad);
+    expect(bid.cacheId).to.equal(serverResponse.body.cacheId);
+    expect(bid.cpm).to.equal(serverResponse.body.cpm);
+    expect(bid.creativeId).to.equal(serverResponse.body.creativeId);
+    expect(bid.currency).to.equal(serverResponse.body.currency);
+    expect(bid.dealId).to.equal(serverResponse.body.dealId);
+    expect(bid.nurl).to.equal(serverResponse.body.nurl);
+    expect(bid.requestId).to.equal(serverResponse.body.requestId);
+    expect(bid.vastUrl).to.equal(serverResponse.body.vastUrl);
+  });
+
+  it('validates interpretResponse - with empty/undefined serverResponse', function () {
+    expect(spec.interpretResponse({})).to.have.lengthOf(0);
+
+    expect(spec.interpretResponse(undefined)).to.have.lengthOf(0);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [x] New bidder adapter : docs PR (prebid.github.io) https://github.com/dailymotion-oss/prebid.github.io/pull/2
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

A new bidder adapter dailymotionBidAdapter added. 

- contact email of the adapter’s maintainer : **ad-leo-engineering@dailymotion.com**

- Test parameters for validating bids:

By setting the following configuration options, you'll get a constant response to any request to validate your adapter integration:

```
config.setConfig({
  dailymotion: {
    api_key: 'dailymotion-testing',
    position: 'preroll'
  }
});
```

```
const adUnits = [{
  code: 'midroll',
  mediaTypes: {
    video: {
      context: 'instream',
      playerSize: [1280, 720],
    },
  },
  bids: [{
    bidder: "dailymotion",
    params: {}
  }]
}];
```

Please note that failing to set these configuration options will result in the adapter not bidding at all.
<!-- For new bidder adapters, please provide the following
Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->
