### PR TITLE
Dailymotion Bid Adaptor: initial release

### DIFF
--- a/modules/dailymotionBidAdapter.md
+++ b/modules/dailymotionBidAdapter.md
@@ -14,7 +14,7 @@ Dailymotion prebid adapter.
 
 Before calling this adapter, you need to set its configuration with a call to setConfig like this:
 
-```
+```javascript
 config.setConfig({
   dailymotion: {
     api_key: 'test_api_key',
@@ -25,6 +25,7 @@ config.setConfig({
 ```
 
 This call must be made before each auction. Here's a description of each parameter:
+
 * `api_key` is your publisher API key. For testing purpose, you can use "dailymotion-testing".
 * `position` parameter is the ad position in the video and must either be "preroll", "midroll" or "postroll".
 * `xid` is the Dailymotion video identifier and should be provided to have better contextual data and higher fillrate.
@@ -33,7 +34,7 @@ This call must be made before each auction. Here's a description of each paramet
 
 By setting the following configuration options, you'll get a constant response to any request to validate your adapter integration:
 
-```
+```javascript
 config.setConfig({
   dailymotion: {
     api_key: 'dailymotion-testing',
@@ -46,7 +47,7 @@ Please note that failing to set these configuration options will result in the a
 
 # Sample video AdUnit
 
-```
+```javascript
 const adUnits = [
   {
     code: 'test-ad-unit',


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [x] New bidder adapter : docs PR (prebid.github.io)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
A new bidder adapter dailymotionBidAdapter added. 
- contact email of the adapter’s maintainer : **ad-leo-engineering@dailymotion.com**
- Test parameters for validating bids:
By setting the following configuration options, you'll get a constant response to any request to validate your adapter integration:
```
config.setConfig({
    dailymotion: {
      api_key: 'dailymotion-testing',
      position: 'preroll'
    }
  });
```
```
 var adUnits = [
  {
     code: 'midroll',
     mediaTypes: {
          video: {
            context: 'instream',
            playerSize: [640, 480],
          },
        },
        bids: [{
          bidder: "dailymotion",
          params: {}
        }]
      }];
```
Please note that failing to set these configuration options will result in the adapter not bidding at all.
<!-- For new bidder adapters, please provide the following
Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->
