### PR TITLE
video api added in bidRequest

### DIFF
--- a/modules/dailymotionBidAdapter.js
+++ b/modules/dailymotionBidAdapter.js
@@ -85,15 +85,16 @@ function getVideoMetadata(bidRequest) {
   };
 
   const videoMetadata = {
-    description: videoParams.description ? videoParams.description : '',
-    duration: videoParams.duration ? videoParams.duration : 0,
-    iabcat2: videoParams.iabcat2 ? videoParams.iabcat2 : '',
-    id: videoParams.id ? videoParams.id : '',
-    lang: videoParams.lang ? videoParams.lang : '',
-    private: videoParams.private ? videoParams.private : false,
-    tags: videoParams.tags ? videoParams.tags : '',
-    title: videoParams.title ? videoParams.title : '',
-    topics: videoParams.topics ? videoParams.topics : '',
+    description: videoParams.description || '',
+    duration: videoParams.duration || 0,
+    iabcat2: videoParams.iabcat2 || '',
+    id: videoParams.id || '',
+    lang: videoParams.lang || '',
+    private: videoParams.private || false,
+    tags: videoParams.tags || '',
+    title: videoParams.title || '',
+    topics: videoParams.topics || '',
+    xid: videoParams.xid || '',
   }
 
   return videoMetadata

--- a/modules/dailymotionBidAdapter.js
+++ b/modules/dailymotionBidAdapter.js
@@ -3,6 +3,37 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { VIDEO } from '../src/mediaTypes.js';
 import { deepAccess } from '../src/utils.js';
 
+/**
+ * Get video metadata from bid request
+ *
+ * @param {BidRequest} bidRequest A valid bid requests that should be sent to the Server.
+ * @return video metadata
+ */
+function getVideoMetadata(bidRequest) {
+  const videoAdUnit = deepAccess(bidRequest, 'mediaTypes.video', {});
+  const videoBidderParams = deepAccess(bidRequest, 'params.video', {});
+
+  const videoParams = {
+    ...videoAdUnit,
+    ...videoBidderParams, // Bidder Specific overrides
+  };
+
+  const videoMetadata = {
+    description: videoParams.description || '',
+    duration: videoParams.duration || 0,
+    iabcat2: videoParams.iabcat2 || '',
+    id: videoParams.id || '',
+    lang: videoParams.lang || '',
+    private: videoParams.private || false,
+    tags: videoParams.tags || '',
+    title: videoParams.title || '',
+    topics: videoParams.topics || '',
+    xid: videoParams.xid || '',
+  };
+
+  return videoMetadata;
+}
+
 export const spec = {
   code: 'dailymotion',
   gvlid: 573,
@@ -17,7 +48,7 @@ export const spec = {
    */
   isBidRequestValid: () => {
     const dmConfig = config.getConfig('dailymotion');
-    return !!(dmConfig?.api_key);
+    return !!dmConfig?.api_key;
   },
 
   /**
@@ -60,7 +91,7 @@ export const spec = {
     },
     options: {
       withCredentials: true,
-      crossOrigin: true
+      crossOrigin: true,
     },
   })),
 
@@ -74,30 +105,5 @@ export const spec = {
    */
   interpretResponse: serverResponse => serverResponse?.body ? [serverResponse.body] : [],
 };
-
-function getVideoMetadata(bidRequest) {
-  const videoAdUnit = deepAccess(bidRequest, 'mediaTypes.video', {});
-  const videoBidderParams = deepAccess(bidRequest, 'params.video', {});
-
-  const videoParams = {
-    ...videoAdUnit,
-    ...videoBidderParams // Bidder Specific overrides
-  };
-
-  const videoMetadata = {
-    description: videoParams.description || '',
-    duration: videoParams.duration || 0,
-    iabcat2: videoParams.iabcat2 || '',
-    id: videoParams.id || '',
-    lang: videoParams.lang || '',
-    private: videoParams.private || false,
-    tags: videoParams.tags || '',
-    title: videoParams.title || '',
-    topics: videoParams.topics || '',
-    xid: videoParams.xid || '',
-  }
-
-  return videoMetadata
-}
 
 registerBidder(spec);

--- a/modules/dailymotionBidAdapter.js
+++ b/modules/dailymotionBidAdapter.js
@@ -1,7 +1,7 @@
 import { config } from '../src/config.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { VIDEO } from '../src/mediaTypes.js';
-import {deepAccess} from '../src/utils.js';
+import { deepAccess } from '../src/utils.js';
 
 export const spec = {
   code: 'dailymotion',

--- a/modules/dailymotionBidAdapter.js
+++ b/modules/dailymotionBidAdapter.js
@@ -1,6 +1,7 @@
 import { config } from '../src/config.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { VIDEO } from '../src/mediaTypes.js';
+import {deepAccess} from '../src/utils.js';
 
 export const spec = {
   code: 'dailymotion',
@@ -55,6 +56,7 @@ export const spec = {
         },
         sizes: bid.sizes || [],
       },
+      video_metadata: getVideoMetadata(bid),
     },
     options: {
       withCredentials: true,
@@ -72,5 +74,29 @@ export const spec = {
    */
   interpretResponse: serverResponse => serverResponse?.body ? [serverResponse.body] : [],
 };
+
+function getVideoMetadata(bidRequest) {
+  const videoAdUnit = deepAccess(bidRequest, 'mediaTypes.video', {});
+  const videoBidderParams = deepAccess(bidRequest, 'params.video', {});
+
+  const videoParams = {
+    ...videoAdUnit,
+    ...videoBidderParams // Bidder Specific overrides
+  };
+
+  const videoMetadata = {
+    description: videoParams.hasOwnProperty('description') ? videoParams.description : '',
+    duration: videoParams.hasOwnProperty('duration') ? videoParams.duration : 0,
+    iabcat2: videoParams.hasOwnProperty('iabcat2') ? videoParams.iabcat2 : '',
+    id: videoParams.hasOwnProperty('id') ? videoParams.id : '',
+    lang: videoParams.hasOwnProperty('lang') ? videoParams.lang : '',
+    private: videoParams.hasOwnProperty('private') ? videoParams.private : false,
+    tags: videoParams.hasOwnProperty('tags') ? videoParams.tags : '',
+    title: videoParams.hasOwnProperty('title') ? videoParams.title : '',
+    topics: videoParams.hasOwnProperty('topics') ? videoParams.topics : '',
+  }
+
+  return videoMetadata
+}
 
 registerBidder(spec);

--- a/modules/dailymotionBidAdapter.js
+++ b/modules/dailymotionBidAdapter.js
@@ -50,6 +50,7 @@ export const spec = {
         mediaTypes: {
           video: {
             playerSize: bid.mediaTypes?.[VIDEO]?.playerSize || [],
+            api: bid.mediaTypes?.[VIDEO]?.api || [],
           },
         },
         sizes: bid.sizes || [],

--- a/modules/dailymotionBidAdapter.js
+++ b/modules/dailymotionBidAdapter.js
@@ -17,7 +17,7 @@ export const spec = {
    */
   isBidRequestValid: () => {
     const dmConfig = config.getConfig('dailymotion');
-    return !!(dmConfig?.api_key && dmConfig?.position);
+    return !!(dmConfig?.api_key);
   },
 
   /**

--- a/modules/dailymotionBidAdapter.js
+++ b/modules/dailymotionBidAdapter.js
@@ -85,15 +85,15 @@ function getVideoMetadata(bidRequest) {
   };
 
   const videoMetadata = {
-    description: videoParams.hasOwnProperty('description') ? videoParams.description : '',
-    duration: videoParams.hasOwnProperty('duration') ? videoParams.duration : 0,
-    iabcat2: videoParams.hasOwnProperty('iabcat2') ? videoParams.iabcat2 : '',
-    id: videoParams.hasOwnProperty('id') ? videoParams.id : '',
-    lang: videoParams.hasOwnProperty('lang') ? videoParams.lang : '',
-    private: videoParams.hasOwnProperty('private') ? videoParams.private : false,
-    tags: videoParams.hasOwnProperty('tags') ? videoParams.tags : '',
-    title: videoParams.hasOwnProperty('title') ? videoParams.title : '',
-    topics: videoParams.hasOwnProperty('topics') ? videoParams.topics : '',
+    description: videoParams.description ? videoParams.description : '',
+    duration: videoParams.duration ? videoParams.duration : 0,
+    iabcat2: videoParams.iabcat2 ? videoParams.iabcat2 : '',
+    id: videoParams.id ? videoParams.id : '',
+    lang: videoParams.lang ? videoParams.lang : '',
+    private: videoParams.private ? videoParams.private : false,
+    tags: videoParams.tags ? videoParams.tags : '',
+    title: videoParams.title ? videoParams.title : '',
+    topics: videoParams.topics ? videoParams.topics : '',
   }
 
   return videoMetadata

--- a/modules/dailymotionBidAdapter.md
+++ b/modules/dailymotionBidAdapter.md
@@ -96,7 +96,7 @@ Following video metadata fields can be added in mediaTypes.video or bids.params.
 * `duration` - Video duration in seconds
 * `iabcat2` - Video IAB category
 * `id` - Video unique ID in host video infrastructure
-* `lang` - Main language used in the video
+* `lang` - ISO 639-1 code for main language used in the video
 * `private` - True if video is not publicly available
 * `tags` - Tags for the video, comma separated
 * `title` - Video title

--- a/modules/dailymotionBidAdapter.md
+++ b/modules/dailymotionBidAdapter.md
@@ -55,6 +55,7 @@ const adUnits = [
       video: {
         context: 'instream',
         playerSize: [1280, 720],
+        api: [2,7],
       },
     },
     bids: [{

--- a/modules/dailymotionBidAdapter.md
+++ b/modules/dailymotionBidAdapter.md
@@ -56,15 +56,48 @@ const adUnits = [
         context: 'instream',
         playerSize: [1280, 720],
         api: [2,7],
+        description: 'this is a video description',
+        duration: 556,
+        iabcat2: 'test_cat',
+        id: '54321',
+        lang: 'FR',
+        private: false,
+        tags: 'tag_1,tag_2,tag_3',
+        title: 'test video',
+        topics: 'topic_1, topic_2',
       },
     },
     bids: [{
       bidder: "dailymotion",
-      params: {}
+      params: {
+        video: {
+          description: 'this is a test video description',
+          duration: 330,
+          iabcat2: 'test_cat',
+          id: '54321',
+          lang: 'FR',
+          private: false,
+          tags: 'tag_1,tag_2,tag_3',
+          title: 'test video',
+          topics: 'topic_1, topic_2, topic_3',
+        }
+      }
     }]
   }
 ];
 ```
+
+Following video metadata fields can be added in mediaTypes.video or bids.params.video. If a field exists in both places, it will be overridden by bids.params.video.
+
+* `description` - Video description
+* `duration` - Video duration in seconds
+* `iabcat2` - Video IAB category
+* `id` - Video unique ID in host video infrastructure
+* `lang` - Main language used in the video
+* `private` - True if video is not publicly available
+* `tags` - Tags for the video, comma separated
+* `title` - Video title
+* `topics` - Main topics for the video, comma separated
 
 # Integrating the adapter
 

--- a/modules/dailymotionBidAdapter.md
+++ b/modules/dailymotionBidAdapter.md
@@ -12,34 +12,35 @@ Dailymotion prebid adapter.
 
 # Configuration options
 
-Before calling this adapter, you need to set its configuration with a call to setConfig like this:
+Before calling this adapter, you need to set its configuration with a call like this:
 
 ```javascript
-config.setConfig({
-  dailymotion: {
-    api_key: 'test_api_key',
-    position: 'test_position',
-    xid: 'x123456'
-  }
+pbjs.setBidderConfig({
+    bidders: ["dailymotion"],
+    config: {
+        dailymotion: {
+            api_key: 'fake_api_key',
+        }
+    }
 });
 ```
 
-This call must be made before each auction. Here's a description of each parameter:
+This call must be made before the first auction to allow proper authentication with our servers.
 
-* `api_key` is your publisher API key. For testing purpose, you can use "dailymotion-testing".
-* `position` parameter is the ad position in the video and must either be "preroll", "midroll" or "postroll".
-* `xid` is the Dailymotion video identifier and should be provided to have better contextual data and higher fillrate.
+`api_key` is your publisher API key. For testing purpose, you can use "dailymotion-testing".
 
 # Test Parameters
 
 By setting the following configuration options, you'll get a constant response to any request to validate your adapter integration:
 
 ```javascript
-config.setConfig({
-  dailymotion: {
-    api_key: 'dailymotion-testing',
-    position: 'preroll'
-  }
+pbjs.setBidderConfig({
+    bidders: ["dailymotion"],
+    config: {
+        dailymotion: {
+            api_key: 'dailymotion-testing'
+        }
+    }
 });
 ```
 
@@ -65,6 +66,7 @@ const adUnits = [
         tags: 'tag_1,tag_2,tag_3',
         title: 'test video',
         topics: 'topic_1, topic_2',
+        xid: 'x123456'
       },
     },
     bids: [{
@@ -80,6 +82,7 @@ const adUnits = [
           tags: 'tag_1,tag_2,tag_3',
           title: 'test video',
           topics: 'topic_1, topic_2, topic_3',
+          xid: 'x123456'
         }
       }
     }]
@@ -98,6 +101,7 @@ Following video metadata fields can be added in mediaTypes.video or bids.params.
 * `tags` - Tags for the video, comma separated
 * `title` - Video title
 * `topics` - Main topics for the video, comma separated
+* `xid` - Dailymotion video identifier (only applicable if using the Dailymotion player) and allows better targeting
 
 # Integrating the adapter
 

--- a/test/spec/modules/dailymotionBidAdapter_spec.js
+++ b/test/spec/modules/dailymotionBidAdapter_spec.js
@@ -4,6 +4,17 @@ import { spec } from 'modules/dailymotionBidAdapter.js';
 import { VIDEO } from '../../../src/mediaTypes';
 
 describe('dailymotionBidAdapterTests', () => {
+  const videoMetadata = {
+    description: 'this is a test video',
+    duration: 556,
+    iabcat2: 'test_cat',
+    id: '54321',
+    lang: 'FR',
+    private: 'false',
+    tags: 'tag_1,tag_2,tag_3',
+    title: 'test video',
+    topics: 'topic_1, topic_2',
+  }
   // Validate that isBidRequestValid only validates requests
   // with both api_key and position config parameters set
   it('validates isBidRequestValid', () => {
@@ -44,9 +55,22 @@ describe('dailymotionBidAdapterTests', () => {
         video: {
           playerSize: [[1280, 720]],
           api: [2, 7],
+          description: 'this is a test video',
+          duration: 556,
+          iabcat2: 'test_cat',
         },
       },
       sizes: [[1920, 1080]],
+      params: {
+        video: {
+          id: '54321',
+          lang: 'FR',
+          private: 'false',
+          tags: 'tag_1,tag_2,tag_3',
+          title: 'test video',
+          topics: 'topic_1, topic_2',
+        }
+      },
     }];
 
     const bidderRequestData = {
@@ -68,9 +92,14 @@ describe('dailymotionBidAdapterTests', () => {
 
     expect(reqData.config).to.eql(dmConfig);
     expect(reqData.coppa).to.be.true;
-
+    // eslint-disable-next-line no-console
+    console.log('abc', reqData.video_metadata);
     expect(reqData.bidder_request).to.eql(bidderRequestData)
-    expect(reqData.request).to.eql(bidRequestData[0]);
+    expect(reqData.request.auctionId).to.eql(bidRequestData[0].auctionId);
+    expect(reqData.request.bidId).to.eql(bidRequestData[0].bidId);
+    expect(reqData.request.mediaTypes.video.api).to.eql(bidRequestData[0].mediaTypes.video.api);
+    expect(reqData.request.mediaTypes.video.playerSize).to.eql(bidRequestData[0].mediaTypes.video.playerSize);
+    expect(reqData.video_metadata).to.eql(videoMetadata);
   });
 
   // Validate request generation with api key, position, xid
@@ -90,9 +119,22 @@ describe('dailymotionBidAdapterTests', () => {
         video: {
           playerSize: [[1280, 720]],
           api: [2, 7],
+          description: 'this is a test video',
+          duration: 556,
+          iabcat2: 'test_cat',
         },
       },
       sizes: [[1920, 1080]],
+      params: {
+        video: {
+          id: '54321',
+          lang: 'FR',
+          private: 'false',
+          tags: 'tag_1,tag_2,tag_3',
+          title: 'test video',
+          topics: 'topic_1, topic_2',
+        }
+      },
     }];
 
     const bidderRequestData = {
@@ -123,7 +165,11 @@ describe('dailymotionBidAdapterTests', () => {
       },
     });
 
-    expect(reqData.request).to.eql(bidRequestData[0]);
+    expect(reqData.request.auctionId).to.eql(bidRequestData[0].auctionId);
+    expect(reqData.request.mediaTypes.video.playerSize).to.eql(bidRequestData[0].mediaTypes.video.playerSize);
+    expect(reqData.request.bidId).to.eql(bidRequestData[0].bidId);
+    expect(reqData.request.mediaTypes.video.api).to.eql(bidRequestData[0].mediaTypes.video.api);
+    expect(reqData.video_metadata).to.eql(videoMetadata);
   });
 
   it('validates buildRequests - with default values on empty bid & bidder request', () => {

--- a/test/spec/modules/dailymotionBidAdapter_spec.js
+++ b/test/spec/modules/dailymotionBidAdapter_spec.js
@@ -43,7 +43,7 @@ describe('dailymotionBidAdapterTests', () => {
       mediaTypes: {
         video: {
           playerSize: [[1280, 720]],
-          api: [[2, 7]],
+          api: [2, 7],
         },
       },
       sizes: [[1920, 1080]],
@@ -89,7 +89,7 @@ describe('dailymotionBidAdapterTests', () => {
       mediaTypes: {
         video: {
           playerSize: [[1280, 720]],
-          api: [[2, 7]],
+          api: [2, 7],
         },
       },
       sizes: [[1920, 1080]],

--- a/test/spec/modules/dailymotionBidAdapter_spec.js
+++ b/test/spec/modules/dailymotionBidAdapter_spec.js
@@ -10,7 +10,7 @@ describe('dailymotionBidAdapterTests', () => {
     iabcat2: 'test_cat',
     id: '54321',
     lang: 'FR',
-    private: 'false',
+    private: false,
     tags: 'tag_1,tag_2,tag_3',
     title: 'test video',
     topics: 'topic_1, topic_2',
@@ -56,16 +56,18 @@ describe('dailymotionBidAdapterTests', () => {
           playerSize: [[1280, 720]],
           api: [2, 7],
           description: 'this is a test video',
-          duration: 556,
+          duration: 300,
           iabcat2: 'test_cat',
+          lang: 'ENG',
         },
       },
       sizes: [[1920, 1080]],
       params: {
         video: {
+          duration: 556,
           id: '54321',
           lang: 'FR',
-          private: 'false',
+          private: false,
           tags: 'tag_1,tag_2,tag_3',
           title: 'test video',
           topics: 'topic_1, topic_2',
@@ -92,8 +94,6 @@ describe('dailymotionBidAdapterTests', () => {
 
     expect(reqData.config).to.eql(dmConfig);
     expect(reqData.coppa).to.be.true;
-    // eslint-disable-next-line no-console
-    console.log('abc', reqData.video_metadata);
     expect(reqData.bidder_request).to.eql(bidderRequestData)
     expect(reqData.request.auctionId).to.eql(bidRequestData[0].auctionId);
     expect(reqData.request.bidId).to.eql(bidRequestData[0].bidId);
@@ -120,16 +120,17 @@ describe('dailymotionBidAdapterTests', () => {
           playerSize: [[1280, 720]],
           api: [2, 7],
           description: 'this is a test video',
-          duration: 556,
+          duration: 300,
           iabcat2: 'test_cat',
         },
       },
       sizes: [[1920, 1080]],
       params: {
         video: {
+          duration: 556,
           id: '54321',
           lang: 'FR',
-          private: 'false',
+          private: false,
           tags: 'tag_1,tag_2,tag_3',
           title: 'test video',
           topics: 'topic_1, topic_2',

--- a/test/spec/modules/dailymotionBidAdapter_spec.js
+++ b/test/spec/modules/dailymotionBidAdapter_spec.js
@@ -43,6 +43,7 @@ describe('dailymotionBidAdapterTests', () => {
       mediaTypes: {
         video: {
           playerSize: [[1280, 720]],
+          api: [[2, 7]],
         },
       },
       sizes: [[1920, 1080]],
@@ -88,6 +89,7 @@ describe('dailymotionBidAdapterTests', () => {
       mediaTypes: {
         video: {
           playerSize: [[1280, 720]],
+          api: [[2, 7]],
         },
       },
       sizes: [[1920, 1080]],
@@ -159,6 +161,7 @@ describe('dailymotionBidAdapterTests', () => {
       mediaTypes: {
         video: {
           playerSize: [],
+          api: [],
         },
       },
       sizes: [],

--- a/test/spec/modules/dailymotionBidAdapter_spec.js
+++ b/test/spec/modules/dailymotionBidAdapter_spec.js
@@ -14,9 +14,9 @@ describe('dailymotionBidAdapterTests', () => {
     tags: 'tag_1,tag_2,tag_3',
     title: 'test video',
     topics: 'topic_1, topic_2',
+    xid: 'x123456'
   }
-  // Validate that isBidRequestValid only validates requests
-  // with both api_key and position config parameters set
+  // Validate that isBidRequestValid only validates requests with api_key
   it('validates isBidRequestValid', () => {
     config.setConfig({ dailymotion: {} });
     expect(spec.isBidRequestValid({
@@ -26,23 +26,12 @@ describe('dailymotionBidAdapterTests', () => {
     config.setConfig({ dailymotion: { api_key: 'test_api_key' } });
     expect(spec.isBidRequestValid({
       bidder: 'dailymotion',
-    })).to.be.false;
-
-    config.setConfig({ dailymotion: { position: 'test_position' } });
-    expect(spec.isBidRequestValid({
-      bidder: 'dailymotion',
-    })).to.be.false;
-
-    config.setConfig({ dailymotion: { api_key: 'test_api_key', position: 'test_position' } });
-    expect(spec.isBidRequestValid({
-      bidder: 'dailymotion',
     })).to.be.true;
   });
 
-  // Validate request generation with api key & position only
-  it('validates buildRequests - with api key & position', () => {
-    const dmConfig = { api_key: 'test_api_key', position: 'test_position' };
-
+  // Validate request generation
+  it('validates buildRequests', () => {
+    const dmConfig = { api_key: 'test_api_key' };
     config.setConfig({
       dailymotion: dmConfig,
       coppa: true,
@@ -71,6 +60,7 @@ describe('dailymotionBidAdapterTests', () => {
           tags: 'tag_1,tag_2,tag_3',
           title: 'test video',
           topics: 'topic_1, topic_2',
+          xid: 'x123456'
         }
       },
     }];
@@ -102,84 +92,8 @@ describe('dailymotionBidAdapterTests', () => {
     expect(reqData.video_metadata).to.eql(videoMetadata);
   });
 
-  // Validate request generation with api key, position, xid
-  it('validates buildRequests - with auth & xid', () => {
-    const dmConfig = {
-      api_key: 'test_api_key',
-      position: 'test_position',
-      xid: 'x123456',
-    };
-
-    config.setConfig({ dailymotion: dmConfig, coppa: undefined });
-
-    const bidRequestData = [{
-      auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
-      bidId: 123456,
-      mediaTypes: {
-        video: {
-          playerSize: [[1280, 720]],
-          api: [2, 7],
-          description: 'this is a test video',
-          duration: 300,
-          iabcat2: 'test_cat',
-        },
-      },
-      sizes: [[1920, 1080]],
-      params: {
-        video: {
-          duration: 556,
-          id: '54321',
-          lang: 'FR',
-          private: false,
-          tags: 'tag_1,tag_2,tag_3',
-          title: 'test video',
-          topics: 'topic_1, topic_2',
-        }
-      },
-    }];
-
-    const bidderRequestData = {
-      refererInfo: {
-        page: 'https://publisher.com',
-      },
-      uspConsent: '1YN-',
-      gdprConsent: {
-        apiVersion: 2,
-        consentString: 'xxx',
-        gdprApplies: 1,
-      },
-    };
-
-    const [request] = spec.buildRequests(bidRequestData, bidderRequestData);
-    const { data: reqData } = request;
-
-    expect(request.url).to.equal('https://pb.dmxleo.com');
-
-    expect(reqData.config).to.eql(dmConfig);
-    expect(reqData.coppa).to.be.undefined;
-
-    expect(reqData.bidder_request).to.eql({
-      ...bidderRequestData,
-      gdprConsent: {
-        ...bidderRequestData.gdprConsent,
-        gdprApplies: true, // Verify cast to boolean
-      },
-    });
-
-    expect(reqData.request.auctionId).to.eql(bidRequestData[0].auctionId);
-    expect(reqData.request.mediaTypes.video.playerSize).to.eql(bidRequestData[0].mediaTypes.video.playerSize);
-    expect(reqData.request.bidId).to.eql(bidRequestData[0].bidId);
-    expect(reqData.request.mediaTypes.video.api).to.eql(bidRequestData[0].mediaTypes.video.api);
-    expect(reqData.video_metadata).to.eql(videoMetadata);
-  });
-
   it('validates buildRequests - with default values on empty bid & bidder request', () => {
-    const dmConfig = {
-      api_key: 'test_api_key',
-      position: 'test_position',
-      xid: 'x123456',
-    };
-
+    const dmConfig = { api_key: 'test_api_key' };
     config.setConfig({ dailymotion: dmConfig, coppa: false });
 
     const [request] = spec.buildRequests([{}], {});
@@ -216,12 +130,7 @@ describe('dailymotionBidAdapterTests', () => {
   });
 
   it('validates buildRequests - with empty/undefined validBidRequests', () => {
-    const dmConfig = {
-      api_key: 'test_api_key',
-      position: 'test_position',
-      xid: 'x123456',
-    };
-
+    const dmConfig = { api_key: 'test_api_key' };
     config.setConfig({ dailymotion: dmConfig });
 
     expect(spec.buildRequests([], {})).to.have.lengthOf(0);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
This PR includes changes to add api array for video mediatype. default is empty.
```
{
 request: {
        mediaTypes: {
          video: {
            api: [2,7],
          },
        },
}}
```
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
Tests are added for api.