### PR TITLE
Dailymotion Bid Adaptor: support video metadata

### DIFF
--- a/modules/dailymotionBidAdapter.md
+++ b/modules/dailymotionBidAdapter.md
@@ -12,34 +12,35 @@ Dailymotion prebid adapter.
 
 # Configuration options
 
-Before calling this adapter, you need to set its configuration with a call to setConfig like this:
+Before calling this adapter, you need to set its configuration with a call like this:
 
 ```javascript
-config.setConfig({
-  dailymotion: {
-    api_key: 'test_api_key',
-    position: 'test_position',
-    xid: 'x123456'
-  }
+pbjs.setBidderConfig({
+    bidders: ["dailymotion"],
+    config: {
+        dailymotion: {
+            api_key: 'fake_api_key',
+        }
+    }
 });
 ```
 
-This call must be made before each auction. Here's a description of each parameter:
+This call must be made before the first auction to allow proper authentication with our servers.
 
-* `api_key` is your publisher API key. For testing purpose, you can use "dailymotion-testing".
-* `position` parameter is the ad position in the video and must either be "preroll", "midroll" or "postroll".
-* `xid` is the Dailymotion video identifier and should be provided to have better contextual data and higher fillrate.
+`api_key` is your publisher API key. For testing purpose, you can use "dailymotion-testing".
 
 # Test Parameters
 
 By setting the following configuration options, you'll get a constant response to any request to validate your adapter integration:
 
 ```javascript
-config.setConfig({
-  dailymotion: {
-    api_key: 'dailymotion-testing',
-    position: 'preroll'
-  }
+pbjs.setBidderConfig({
+    bidders: ["dailymotion"],
+    config: {
+        dailymotion: {
+            api_key: 'dailymotion-testing'
+        }
+    }
 });
 ```
 
@@ -55,15 +56,52 @@ const adUnits = [
       video: {
         context: 'instream',
         playerSize: [1280, 720],
+        api: [2,7],
+        description: 'this is a video description',
+        duration: 556,
+        iabcat2: 'test_cat',
+        id: '54321',
+        lang: 'FR',
+        private: false,
+        tags: 'tag_1,tag_2,tag_3',
+        title: 'test video',
+        topics: 'topic_1, topic_2',
+        xid: 'x123456'
       },
     },
     bids: [{
       bidder: "dailymotion",
-      params: {}
+      params: {
+        video: {
+          description: 'this is a test video description',
+          duration: 330,
+          iabcat2: 'test_cat',
+          id: '54321',
+          lang: 'FR',
+          private: false,
+          tags: 'tag_1,tag_2,tag_3',
+          title: 'test video',
+          topics: 'topic_1, topic_2, topic_3',
+          xid: 'x123456'
+        }
+      }
     }]
   }
 ];
 ```
+
+Following video metadata fields can be added in mediaTypes.video or bids.params.video. If a field exists in both places, it will be overridden by bids.params.video.
+
+* `description` - Video description
+* `duration` - Video duration in seconds
+* `iabcat2` - Video IAB category
+* `id` - Video unique ID in host video infrastructure
+* `lang` - ISO 639-1 code for main language used in the video
+* `private` - True if video is not publicly available
+* `tags` - Tags for the video, comma separated
+* `title` - Video title
+* `topics` - Main topics for the video, comma separated
+* `xid` - Dailymotion video identifier (only applicable if using the Dailymotion player) and allows better targeting
 
 # Integrating the adapter
 


### PR DESCRIPTION
## Type of change

- [x] Feature

## Description of change

- Adds support for getting & sending video metadata in `buildRequests()`

## Other information

- Addresses feedback of [patmmccann](https://github.com/patmmccann) on https://github.com/prebid/Prebid.js/pull/10970#discussion_r1501351540
