### PR TITLE
feat(LEO-528): Allow multiple IAB categories level 2 in video metadata

### DIFF
--- a/modules/dailymotionBidAdapter.js
+++ b/modules/dailymotionBidAdapter.js
@@ -21,7 +21,7 @@ function getVideoMetadata(bidRequest) {
   const videoMetadata = {
     description: videoParams.description || '',
     duration: videoParams.duration || 0,
-    iabcat2: videoParams.iabcat2 || '',
+    iabcat2: Array.isArray(videoParams.iabcat2) ? videoParams.iabcat2 : [],
     id: videoParams.id || '',
     lang: videoParams.lang || '',
     private: videoParams.private || false,

--- a/modules/dailymotionBidAdapter.md
+++ b/modules/dailymotionBidAdapter.md
@@ -59,7 +59,7 @@ const adUnits = [
         api: [2,7],
         description: 'this is a video description',
         duration: 556,
-        iabcat2: 'test_cat',
+        iabcat2: ['6', '17'],
         id: '54321',
         lang: 'FR',
         private: false,
@@ -75,7 +75,7 @@ const adUnits = [
         video: {
           description: 'this is a test video description',
           duration: 330,
-          iabcat2: 'test_cat',
+          iabcat2: ['6', '17'],
           id: '54321',
           lang: 'FR',
           private: false,
@@ -94,14 +94,14 @@ Following video metadata fields can be added in mediaTypes.video or bids.params.
 
 * `description` - Video description
 * `duration` - Video duration in seconds
-* `iabcat2` - Video IAB category
+* `iabcat2` - List of IAB category IDs from the [2.0 taxonomy](https://github.com/InteractiveAdvertisingBureau/Taxonomies/blob/main/Content%20Taxonomies/Content%20Taxonomy%202.0.tsv)
 * `id` - Video unique ID in host video infrastructure
 * `lang` - ISO 639-1 code for main language used in the video
 * `private` - True if video is not publicly available
 * `tags` - Tags for the video, comma separated
 * `title` - Video title
 * `topics` - Main topics for the video, comma separated
-* `xid` - Dailymotion video identifier (only applicable if using the Dailymotion player) and allows better targeting
+* `xid` - Dailymotion video identifier (only applicable if using the Dailymotion player), allows better targeting
 
 # Integrating the adapter
 

--- a/test/spec/modules/dailymotionBidAdapter_spec.js
+++ b/test/spec/modules/dailymotionBidAdapter_spec.js
@@ -42,7 +42,7 @@ describe('dailymotionBidAdapterTests', () => {
           api: [2, 7],
           description: 'this is a test video',
           duration: 300,
-          iabcat2: 'test_cat',
+          iabcat2: ['6', '17'],
           lang: 'ENG',
           startdelay: 0,
         },
@@ -152,6 +152,19 @@ describe('dailymotionBidAdapterTests', () => {
         },
       },
       sizes: [],
+    });
+
+    expect(reqData.video_metadata).to.eql({
+      description: '',
+      duration: 0,
+      iabcat2: [],
+      id: '',
+      lang: '',
+      private: false,
+      tags: '',
+      title: '',
+      topics: '',
+      xid: '',
     });
   });
 


### PR DESCRIPTION
The same way as we can have an array of IAB categories level 1 in the ORTB request, this PR introduces an array for the IAB categories level 2.

To be forward compatible with level [2.2](https://github.com/InteractiveAdvertisingBureau/Taxonomies/blob/main/Content%20Taxonomies/Content%20Taxonomy%202.2.tsv) and [3.0](https://github.com/InteractiveAdvertisingBureau/Taxonomies/blob/main/Content%20Taxonomies/Content%20Taxonomy%203.0.tsv) specifications, the category IDs should be sent as strings.