### PR TITLE
Dailymotion Bid Adaptor: fix lint error

### DIFF
--- a/modules/dailymotionBidAdapter.js
+++ b/modules/dailymotionBidAdapter.js
@@ -72,10 +72,10 @@ export const spec = {
         },
         uspConsent: bidderRequest?.uspConsent || '',
         gppConsent: {
-          gppString: deepAccess(bidderRequest, 'gppConsent.gppString')
-            || deepAccess(bidderRequest, 'ortb2.regs.gpp', ''),
-          applicableSections: deepAccess(bidderRequest, 'gppConsent.applicableSections')
-            || deepAccess(bidderRequest, 'ortb2.regs.gpp_sid', []),
+          gppString: deepAccess(bidderRequest, 'gppConsent.gppString') ||
+            deepAccess(bidderRequest, 'ortb2.regs.gpp', ''),
+          applicableSections: deepAccess(bidderRequest, 'gppConsent.applicableSections') ||
+            deepAccess(bidderRequest, 'ortb2.regs.gpp_sid', []),
         },
       },
       config: {


### PR DESCRIPTION
Fix linting errors:

   76:15  error    '||' should be placed at the end of the line  operator-linebreak
   78:15  error    '||' should be placed at the end of the line  operator-linebreak