### PR TITLE
Dailymotion Bid Adapter: fix user sync parsing

### DIFF
--- a/modules/dailymotionBidAdapter.js
+++ b/modules/dailymotionBidAdapter.js
@@ -224,7 +224,7 @@ export const spec = {
       const pixelSyncs = [];
 
       serverResponses.forEach((response) => {
-        (response.user_syncs || []).forEach((syncUrl) => {
+        (response?.body?.userSyncs || []).forEach((syncUrl) => {
           if (syncUrl.type === 'image') {
             pixelSyncs.push({ url: syncUrl.url, type: 'image' });
           }

--- a/test/spec/modules/dailymotionBidAdapter_spec.js
+++ b/test/spec/modules/dailymotionBidAdapter_spec.js
@@ -647,7 +647,7 @@ describe('dailymotionBidAdapterTests', () => {
 
     // No permissions
     {
-      const responses = [{ user_syncs: [{ url: 'https://usersyncurl.com', type: 'image' }] }];
+      const responses = [{ body: { userSyncs: [{ url: 'https://usersyncurl.com', type: 'image' }] } }];
       const syncOptions = { iframeEnabled: false, pixelEnabled: false };
 
       expect(config.runWithBidder(
@@ -656,7 +656,7 @@ describe('dailymotionBidAdapterTests', () => {
       )).to.eql([]);
     }
 
-    // Has permissions but no user_syncs urls
+    // Has permissions but no userSyncs urls
     {
       const responses = [{}];
       const syncOptions = { iframeEnabled: false, pixelEnabled: true };
@@ -667,14 +667,16 @@ describe('dailymotionBidAdapterTests', () => {
       )).to.eql([]);
     }
 
-    // Return user_syncs urls for pixels
+    // Return userSyncs urls for pixels
     {
       const responses = [{
-        user_syncs: [
-          { url: 'https://usersyncurl.com', type: 'image' },
-          { url: 'https://usersyncurl2.com', type: 'image' },
-          { url: 'https://usersyncurl3.com', type: 'iframe' }
-        ],
+        body: {
+          userSyncs: [
+            { url: 'https://usersyncurl.com', type: 'image' },
+            { url: 'https://usersyncurl2.com', type: 'image' },
+            { url: 'https://usersyncurl3.com', type: 'iframe' }
+          ],
+        }
       }];
 
       const syncOptions = { iframeEnabled: false, pixelEnabled: true };
@@ -688,14 +690,16 @@ describe('dailymotionBidAdapterTests', () => {
       ]);
     }
 
-    // Return user_syncs urls for iframes
+    // Return userSyncs urls for iframes
     {
       const responses = [{
-        user_syncs: [
-          { url: 'https://usersyncurl.com', type: 'image' },
-          { url: 'https://usersyncurl2.com', type: 'image' },
-          { url: 'https://usersyncurl3.com', type: 'iframe' }
-        ],
+        body: {
+          userSyncs: [
+            { url: 'https://usersyncurl.com', type: 'image' },
+            { url: 'https://usersyncurl2.com', type: 'image' },
+            { url: 'https://usersyncurl3.com', type: 'iframe' }
+          ],
+        }
       }];
 
       const syncOptions = { iframeEnabled: true, pixelEnabled: true };


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 

## Description of change
This fixes an issue in the server response parsing for user sync, where it was not using the body from the response. I took the occasion to also convert this member to camelCase for consistency with the others.